### PR TITLE
Limit design review workflow to code paths

### DIFF
--- a/.github/workflows/claude-design-review.yml
+++ b/.github/workflows/claude-design-review.yml
@@ -2,8 +2,16 @@ name: Claude Design Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
-  workflow_dispatch:
+    types: [opened, reopened, synchronize]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'supabase/**'
+      - 'pages/**'
+      - 'package.json'
+      - 'next.config.*'
+      - 'tsconfig.*'
 
 jobs:
   design-review:


### PR DESCRIPTION
### Summary
Limited the `claude-design-review.yml` GitHub Actions workflow to only run on pull request events (`opened`, `reopened`, `synchronize`) and specifically when changes occur in core application code paths (e.g., `app/**`, `components/**`, `lib/**`, `pages/**`, `supabase/**`, and key config files like `package.json`, `next.config.*`, `tsconfig.*`). This prevents the workflow from running on non-code changes like documentation or `.github` folder modifications, optimizing CI resource usage.

### Risk / Scope
- DB schema or RLS touched? ☐ No
- Payments/Stripe Connect changed? ☐ No
- Queue/automation engine semantics changed? ☐ No
- Public API contracts changed? ☐ No

### Tests
- Unit & Integration run locally/in agent: ☐
- Playwright E2E for critical flows (sign-in → create workflow → test mode → messaging → booking): ☐
- New/updated tests for changed code paths: ☐
- Regression test added for any bug fix: ☐

### Security / Privacy
- RLS preserved or updated with tests: ☐
- Webhook/OAuth signatures verified where applicable: ☐
- No secrets logged or committed: ☐

### Performance / UX
- Hot paths assessed (notes if any): ☐
- UI changes include screenshots/GIFs: ☐

### Migrations (if any)
- Up/Down scripts present: ☐
- Rollback plan noted: ☐

### Automation
- Bugbot review requested / addressed: ☐
- CI green: ☐

---
[Slack Thread](https://atlasgyms.slack.com/archives/C09DBR8QCLW/p1756911909149589?thread_ts=1756911909.149589&cid=C09DBR8QCLW)

<a href="https://cursor.com/background-agent?bcId=bc-13e4033f-ae80-4aef-8ef9-a65ae8afdddf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13e4033f-ae80-4aef-8ef9-a65ae8afdddf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

