### PR TITLE
Fix failed to load customer profile error

### DIFF
--- a/app/members/add/page.tsx
+++ b/app/members/add/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default function AddMemberRedirectPage() {
+  redirect('/members/new')
+}
+

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -294,7 +294,7 @@ function MembersContent() {
             <p className="text-gray-400 mt-1">Manage your gym members and their memberships</p>
           </div>
           <Link
-            href="/members/add"
+            href="/members/new"
             className="bg-orange-600 hover:bg-orange-700 text-white px-4 py-2 rounded-lg transition-colors flex items-center"
           >
             <Plus className="w-4 h-4 mr-2" />


### PR DESCRIPTION
### Summary
Fixed an error where navigating to `/members/add` resulted in "Failed to load customer profile". This was due to `/members/add` being incorrectly caught by the dynamic route `/members/[customerId]`.
The fix involves:
1.  Updating the "Add Member" link in `app/members/page.tsx` to point to the correct `/members/new` route.
2.  Adding a redirect page at `app/members/add/page.tsx` to forward users from the old `/members/add` URL to `/members/new`.

### Risk / Scope
- DB schema or RLS touched? ☐ No
- Payments/Stripe Connect changed? ☐ No
- Queue/automation engine semantics changed? ☐ No
- Public API contracts changed? ☐ No

### Tests
- Unit & Integration run locally/in agent: ☐
- Playwright E2E for critical flows (sign-in → create workflow → test mode → messaging → booking): ☐
- New/updated tests for changed code paths: ☐
- Regression test added for any bug fix: ☐

### Security / Privacy
- RLS preserved or updated with tests: ☐
- Webhook/OAuth signatures verified where applicable: ☐
- No secrets logged or committed: ☐

### Performance / UX
- Hot paths assessed (notes if any): ☐
- UI changes include screenshots/GIFs: ☐

### Migrations (if any)
- Up/Down scripts present: ☐
- Rollback plan noted: ☐

### Automation
- Bugbot review requested / addressed: ☐
- CI green: ☐

---
[Slack Thread](https://atlasgyms.slack.com/archives/C09DBR8QCLW/p1756971679409489?thread_ts=1756971679.409489&cid=C09DBR8QCLW)

<a href="https://cursor.com/background-agent?bcId=bc-7163477a-0080-4c11-b121-548e2eccdbe2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7163477a-0080-4c11-b121-548e2eccdbe2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

