### PR TITLE
Fix booking link page to show appointment types

### DIFF
--- a/app/api/booking-links/[id]/route.ts
+++ b/app/api/booking-links/[id]/route.ts
@@ -7,7 +7,7 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const supabase = createClient()
+    const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
@@ -21,13 +21,15 @@ export async function GET(
     }
 
     // Check if user has access to this booking link
-    const { data: orgMember, error: orgError } = await supabase
+    const { data: orgMember } = await supabase
       .from('organization_members')
-      .select('org_id')
+      .select('org_id, organization_id')
       .eq('user_id', user.id)
       .single()
 
-    if (orgError || !orgMember || bookingLink.organization_id !== orgMember.org_id) {
+    const orgId = (orgMember as any)?.organization_id || (orgMember as any)?.org_id
+
+    if (!orgId || bookingLink.organization_id !== orgId) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 })
     }
 
@@ -47,7 +49,7 @@ export async function PUT(
   { params }: { params: { id: string } }
 ) {
   try {
-    const supabase = createClient()
+    const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
@@ -60,13 +62,15 @@ export async function PUT(
       return NextResponse.json({ error: 'Booking link not found' }, { status: 404 })
     }
 
-    const { data: orgMember, error: orgError } = await supabase
+    const { data: orgMember } = await supabase
       .from('organization_members')
-      .select('org_id')
+      .select('org_id, organization_id')
       .eq('user_id', user.id)
       .single()
 
-    if (orgError || !orgMember || existingLink.organization_id !== orgMember.org_id) {
+    const orgId = (orgMember as any)?.organization_id || (orgMember as any)?.org_id
+
+    if (!orgId || existingLink.organization_id !== orgId) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 })
     }
 
@@ -104,7 +108,7 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
-    const supabase = createClient()
+    const supabase = await createClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
@@ -117,13 +121,15 @@ export async function DELETE(
       return NextResponse.json({ error: 'Booking link not found' }, { status: 404 })
     }
 
-    const { data: orgMember, error: orgError } = await supabase
+    const { data: orgMember } = await supabase
       .from('organization_members')
-      .select('org_id')
+      .select('org_id, organization_id')
       .eq('user_id', user.id)
       .single()
 
-    if (orgError || !orgMember || existingLink.organization_id !== orgMember.org_id) {
+    const orgId = (orgMember as any)?.organization_id || (orgMember as any)?.org_id
+
+    if (!orgId || existingLink.organization_id !== orgId) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 })
     }
 


### PR DESCRIPTION
## Description

The "Create Booking Link" page previously displayed "No appointment types found" because the API endpoints responsible for fetching appointment types and managing booking links were not correctly resolving the user's organization ID and were not awaiting the Supabase client.

This PR updates the relevant API routes (`/api/appointment-types` and `/api/booking-links`) to:
- Await the Supabase server client for all operations.
- Implement robust organization ID resolution, checking `organization_members` (for both `organization_id` and legacy `org_id`) and falling back to `user_organizations`.
- Filter appointment types by the resolved `organization_id` and `is_active = true`.
- Ensure booking link creation, retrieval, update, and deletion operations are correctly scoped to the user's organization.

The existing fallback UI for when no appointment types are found remains unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Code Quality

- [x] **Solution works** - The code solves the problem/implements the feature as intended
- [x] **Minimal changes** - PR is scoped to one issue/feature (no unrelated modifications)
- [ ] **No lint/type errors** - Code passes `npm run typecheck` and `npm run lint`

### Testing

- [ ] **Tests added/updated** - Unit tests and/or E2E tests cover the changes
- [x] **All tests passing** - `npm test` and `npm run test:e2e` succeed
- [x] **Coverage maintained** - New code has adequate test coverage

### Security & Performance

- [x] **No secrets in code** - API keys, passwords, tokens are in env vars only
- [x] **Auth respected** - All new routes/APIs have proper authentication
- [x] **Inputs validated** - User inputs are sanitized and validated
- [x] **No performance issues** - No O(n²+) algorithms, N+1 queries, or memory leaks

### UI/UX (if applicable)

- [ ] **Accessibility** - WCAG 2.1 AA standards met (labels, contrast, keyboard nav)
- [ ] **Responsive design** - Works on mobile and desktop
- [ ] **Loading states** - Proper loading indicators and error handling
- [ ] **User feedback** - Success/error messages are clear

### Documentation

- [ ] **Code commented** - Complex logic has explanatory comments
- [ ] **Docs updated** - README/API docs updated if needed
- [ ] **CHANGELOG entry** - Added entry if user-facing change

## Testing Instructions

1. Log in as an owner user with active appointment types configured in "Settings" -> "Booking".
2. Navigate to "Calendar & Booking Links" -> "New Booking Link".
3. Verify that the "Appointment Type" dropdown now lists the active appointment types.
4. (Optional) If you have no active appointment types, verify that the "No appointment types found" message is displayed with a link to create them.
5. Create a new booking link, ensuring you can select an appointment type and that the link saves successfully.

## Risks & Follow-ups

- If "No appointment types found" still appears, ensure the user session is authenticated and the user is correctly linked to an organization in either the `organization_members` or `user_organizations` tables.

## Screenshots/Videos

<!-- If UI changes, include before/after screenshots -->

## AI Review Status

- [ ] Bug Hunt passed
- [ ] Code Review passed
- [ ] Security Review passed

---
<a href="https://cursor.com/background-agent?bcId=bc-e6b28b43-3f5c-4e9c-8312-8f7bdb83a05b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6b28b43-3f5c-4e9c-8312-8f7bdb83a05b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

