### PR TITLE
Update date picker locale to en-GB

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en-GB">
       <body className={inter.className}>
         <ErrorBoundaryProvider>
           <AnalyticsProvider>

--- a/atlas-fitness-mobile/src/screens/auth/CompleteProfileScreen.tsx
+++ b/atlas-fitness-mobile/src/screens/auth/CompleteProfileScreen.tsx
@@ -217,7 +217,7 @@ export default function CompleteProfileScreen() {
               labelStyle={styles.dateButtonLabel}
             >
               {dateOfBirth
-                ? format(dateOfBirth, 'MMMM d, yyyy')
+                ? format(dateOfBirth, 'dd/MM/yyyy')
                 : 'Select Date of Birth'}
             </Button>
 
@@ -226,6 +226,7 @@ export default function CompleteProfileScreen() {
                 value={dateOfBirth || new Date()}
                 mode="date"
                 display="default"
+                locale={Platform.OS === 'ios' ? 'en_GB' : undefined}
                 onChange={(event, selectedDate) => {
                   setShowDatePicker(false);
                   if (selectedDate) {

--- a/gym-coach-platform/app/layout.tsx
+++ b/gym-coach-platform/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en-GB">
       <head>
         <link rel="manifest" href="/manifest.json" />
         <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
## Description

Updated date input formatting across web and mobile applications to correctly display and accept dates in `dd/MM/yyyy` format for UK users. This addresses previous inconsistencies where the US `mm/dd/yyyy` format was used, improving user experience and preventing potential data entry errors.

Specifically:
- Web application layouts (`app/layout.tsx`, `gym-coach-platform/app/layout.tsx`) now set `lang="en-GB"` to leverage browser locale for native date inputs.
- Mobile application's `CompleteProfileScreen` (`atlas-fitness-mobile/src/screens/auth/CompleteProfileScreen.tsx`) now formats the displayed date of birth as `dd/MM/yyyy` and explicitly sets the `DateTimePicker` locale to `en_GB` for iOS.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### Code Quality

- [x] **Solution works** - The code solves the problem/implements the feature as intended
- [x] **Minimal changes** - PR is scoped to one issue/feature (no unrelated modifications)
- [x] **No lint/type errors** - Code passes `npm run typecheck` and `npm run lint`

### Testing

- [ ] **Tests added/updated** - Unit tests and/or E2E tests cover the changes
- [ ] **All tests passing** - `npm test` and `npm run test:e2e` succeed
- [ ] **Coverage maintained** - New code has adequate test coverage

### Security & Performance

- [x] **No secrets in code** - API keys, passwords, tokens are in env vars only
- [x] **Auth respected** - All new routes/APIs have proper authentication
- [x] **Inputs validated** - User inputs are sanitized and validated
- [x] **No performance issues** - No O(n²+) algorithms, N+1 queries, or memory leaks

### UI/UX (if applicable)

- [x] **Accessibility** - WCAG 2.1 AA standards met (labels, contrast, keyboard nav)
- [x] **Responsive design** - Works on mobile and desktop
- [x] **Loading states** - Proper loading indicators and error handling
- [x] **User feedback** - Success/error messages are clear

### Documentation

- [ ] **Code commented** - Complex logic has explanatory comments
- [ ] **Docs updated** - README/API docs updated if needed
- [ ] **CHANGELOG entry** - Added entry if user-facing change

## Testing Instructions

1.  **Web (Add Contact/Edit Profile forms):**
    *   Ensure your browser's locale is set to a UK locale (e.g., `en-GB`).
    *   Navigate to the Add Contact or Edit Profile form.
    *   Enter a date like `05/09/2025` (representing September 5th, 2025).
    *   Verify that the date is displayed and accepted in `dd/MM/yyyy` format (i.e., `05/09/2025`).
    *   Switch your browser's locale to a US locale (e.g., `en-US`).
    *   Confirm that native date inputs now adapt to the `mm/dd/yyyy` format.
2.  **Mobile (Complete Profile screen):**
    *   Open the Complete Profile screen in the mobile app.
    *   Select a date of birth using the date picker.
    *   Verify that the selected date is displayed on the screen in `dd/MM/yyyy` format.
    *   **For iOS devices:** Confirm that the `DateTimePicker` itself (the calendar interface) presents the day before the month (e.g., `5 September` instead of `September 5`).

## Risks & Follow-ups

-   Android `DateTimePicker` behavior relies on the device's locale, while iOS is explicitly set to `en_GB`. This aligns with the task's focus on UK users but might show different behavior if an Android device is set to a non-UK locale.

## Screenshots/Videos

## AI Review Status

- [ ] Bug Hunt passed
- [ ] Code Review passed
- [ ] Security Review passed

---
<a href="https://cursor.com/background-agent?bcId=bc-e64a7396-42a1-4711-8853-34916850bad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e64a7396-42a1-4711-8853-34916850bad1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

