### PR TITLE
Enhance membership details and management UI

### DIFF
--- a/app/components/customers/tabs/MembershipsTab.tsx
+++ b/app/components/customers/tabs/MembershipsTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { createClient } from '@/app/lib/supabase/client'
-import { CreditCard, Calendar, Clock, PauseCircle } from 'lucide-react'
+import { CreditCard, Calendar, Clock, PauseCircle, PlayCircle, XCircle, ArrowUpRight, ChevronDown, ChevronUp, Edit3 } from 'lucide-react'
 import { formatBritishDate, formatBritishCurrency } from '@/app/lib/utils/british-format'
 import AddMembershipModal from '../AddMembershipModal'
 
@@ -15,11 +15,18 @@ export default function MembershipsTab({ customerId }: MembershipsTabProps) {
   const [loading, setLoading] = useState(true)
   const [showAddModal, setShowAddModal] = useState(false)
   const [customerName, setCustomerName] = useState('')
+  const [expandedId, setExpandedId] = useState<string | null>(null)
+  const [showEditModal, setShowEditModal] = useState(false)
+  const [editTarget, setEditTarget] = useState<any | null>(null)
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false)
+  const [upgradeTarget, setUpgradeTarget] = useState<any | null>(null)
+  const [membershipPlans, setMembershipPlans] = useState<any[]>([])
   const supabase = createClient()
 
   useEffect(() => {
     fetchMemberships()
     fetchCustomerName()
+    fetchMembershipPlans()
   }, [customerId])
 
   const fetchCustomerName = async () => {
@@ -57,6 +64,71 @@ export default function MembershipsTab({ customerId }: MembershipsTabProps) {
     } finally {
       setLoading(false)
     }
+  }
+
+  const fetchMembershipPlans = async () => {
+    try {
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) return
+
+      const { data: userOrg } = await supabase
+        .from('user_organizations')
+        .select('organization_id')
+        .eq('user_id', user.id)
+        .single()
+
+      if (!userOrg) return
+
+      const { data } = await supabase
+        .from('membership_plans')
+        .select('*')
+        .eq('organization_id', userOrg.organization_id)
+        .eq('is_active', true)
+        .order('price', { ascending: true })
+
+      setMembershipPlans(data || [])
+    } catch (error) {
+      console.error('Error fetching membership plans:', error)
+    }
+  }
+
+  const updateMembership = async (id: string, updates: any) => {
+    const { error } = await supabase
+      .from('customer_memberships')
+      .update({ ...updates })
+      .eq('id', id)
+    if (error) throw error
+  }
+
+  const handlePauseResume = async (membership: any) => {
+    try {
+      const newStatus = membership.status === 'paused' ? 'active' : 'paused'
+      await updateMembership(membership.id, { status: newStatus })
+      await fetchMemberships()
+    } catch (error) {
+      console.error('Error updating status:', error)
+    }
+  }
+
+  const handleCancel = async (membership: any) => {
+    try {
+      if (!confirm('Cancel this membership? This will end it today.')) return
+      const today = new Date().toISOString().split('T')[0]
+      await updateMembership(membership.id, { status: 'cancelled', end_date: today })
+      await fetchMemberships()
+    } catch (error) {
+      console.error('Error cancelling membership:', error)
+    }
+  }
+
+  const openEdit = (membership: any) => {
+    setEditTarget(membership)
+    setShowEditModal(true)
+  }
+
+  const openUpgrade = (membership: any) => {
+    setUpgradeTarget(membership)
+    setShowUpgradeModal(true)
   }
 
   const getStatusColor = (status: string) => {
@@ -105,11 +177,19 @@ export default function MembershipsTab({ customerId }: MembershipsTabProps) {
       ) : (
         <div className="space-y-4">
           {memberships.map((membership) => (
-            <div key={membership.id} className="bg-gray-800 rounded-lg p-4">
-              <div className="flex items-start justify-between">
+            <div key={membership.id} className="bg-gray-800 rounded-lg">
+              <button
+                className="w-full p-4 flex items-start justify-between text-left"
+                onClick={() => setExpandedId(expandedId === membership.id ? null : membership.id)}
+              >
                 <div>
-                  <h4 className="font-medium text-white">
+                  <h4 className="font-medium text-white flex items-center gap-2">
                     {membership.membership_plan?.name || 'Membership'}
+                    {expandedId === membership.id ? (
+                      <ChevronUp className="h-4 w-4 text-gray-400" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4 text-gray-400" />
+                    )}
                   </h4>
                   <div className="flex items-center gap-4 mt-2 text-sm text-gray-400">
                     <span className="flex items-center gap-1">
@@ -123,6 +203,7 @@ export default function MembershipsTab({ customerId }: MembershipsTabProps) {
                       </span>
                     )}
                   </div>
+
                   <div className="mt-2">
                     <span className="text-lg font-semibold text-white">
                       {formatBritishCurrency(membership.membership_plan?.price || 0)}
@@ -136,23 +217,78 @@ export default function MembershipsTab({ customerId }: MembershipsTabProps) {
                   <span className={`px-3 py-1 text-xs text-white rounded-full ${getStatusColor(membership.status)}`}>
                     {membership.status}
                   </span>
-                  {membership.status === 'active' && (
-                    <button className="mt-2 flex items-center gap-1 text-sm text-gray-400 hover:text-white">
-                      <PauseCircle className="h-4 w-4" />
-                      Pause
-                    </button>
-                  )}
                 </div>
-              </div>
-              
-              {membership.membership_plan?.features && (
-                <div className="mt-4 pt-4 border-t border-gray-700">
-                  <p className="text-sm font-medium text-gray-400 mb-2">Includes:</p>
-                  <ul className="text-sm text-gray-300 space-y-1">
-                    {Object.entries(membership.membership_plan.features).map(([key, value]) => (
-                      <li key={key}>• {key}: {String(value)}</li>
-                    ))}
-                  </ul>
+              </button>
+
+              {expandedId === membership.id && (
+                <div className="px-4 pb-4">
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div className="bg-gray-900 rounded-lg p-4">
+                      <p className="text-xs text-gray-400">Plan</p>
+                      <p className="text-white">{membership.membership_plan?.name || '—'}</p>
+                      <p className="text-xs text-gray-400 mt-2">Billing</p>
+                      <p className="text-white">{formatBritishCurrency(membership.membership_plan?.price || 0)} / {membership.membership_plan?.billing_period || 'month'}</p>
+                    </div>
+                    <div className="bg-gray-900 rounded-lg p-4">
+                      <p className="text-xs text-gray-400">Start Date</p>
+                      <p className="text-white">{formatBritishDate(membership.start_date)}</p>
+                      <p className="text-xs text-gray-400 mt-2">End Date</p>
+                      <p className="text-white">{membership.end_date ? formatBritishDate(membership.end_date) : '—'}</p>
+                    </div>
+                    <div className="bg-gray-900 rounded-lg p-4">
+                      <p className="text-xs text-gray-400">Next Billing</p>
+                      <p className="text-white">{membership.next_billing_date ? formatBritishDate(membership.next_billing_date) : '—'}</p>
+                      <p className="text-xs text-gray-400 mt-2">Notes</p>
+                      <p className="text-white whitespace-pre-wrap">{membership.notes || '—'}</p>
+                    </div>
+                  </div>
+
+                  {membership.membership_plan?.features && (
+                    <div className="mt-4 pt-4 border-t border-gray-700">
+                      <p className="text-sm font-medium text-gray-400 mb-2">Includes:</p>
+                      <ul className="text-sm text-gray-300 space-y-1">
+                        {Object.entries(membership.membership_plan.features).map(([key, value]) => (
+                          <li key={key}>• {key}: {String(value)}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <button
+                      className="px-3 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 flex items-center gap-2"
+                      onClick={(e) => { e.stopPropagation(); setEditTarget(membership); setShowEditModal(true) }}
+                    >
+                      <Edit3 className="h-4 w-4" /> Edit
+                    </button>
+                    {membership.status === 'paused' ? (
+                      <button
+                        className="px-3 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 flex items-center gap-2"
+                        onClick={(e) => { e.stopPropagation(); handlePauseResume(membership) }}
+                      >
+                        <PlayCircle className="h-4 w-4" /> Resume
+                      </button>
+                    ) : (
+                      <button
+                        className="px-3 py-2 bg-yellow-600 text-white rounded-lg hover:bg-yellow-700 flex items-center gap-2"
+                        onClick={(e) => { e.stopPropagation(); handlePauseResume(membership) }}
+                      >
+                        <PauseCircle className="h-4 w-4" /> Pause
+                      </button>
+                    )}
+                    <button
+                      className="px-3 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 flex items-center gap-2"
+                      onClick={(e) => { e.stopPropagation(); handleCancel(membership) }}
+                    >
+                      <XCircle className="h-4 w-4" /> Cancel
+                    </button>
+                    <button
+                      className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 flex items-center gap-2"
+                      onClick={(e) => { e.stopPropagation(); setUpgradeTarget(membership); setShowUpgradeModal(true) }}
+                    >
+                      <ArrowUpRight className="h-4 w-4" /> Upgrade
+                    </button>
+                  </div>
                 </div>
               )}
             </div>
@@ -170,6 +306,155 @@ export default function MembershipsTab({ customerId }: MembershipsTabProps) {
           setShowAddModal(false)
         }}
       />
+      {showEditModal && editTarget && (
+        <EditMembershipModal
+          membership={editTarget}
+          onClose={() => { setShowEditModal(false); setEditTarget(null) }}
+          onSaved={async () => { await fetchMemberships(); setShowEditModal(false); setEditTarget(null) }}
+        />
+      )}
+      {showUpgradeModal && upgradeTarget && (
+        <UpgradeMembershipModal
+          membership={upgradeTarget}
+          plans={membershipPlans}
+          onClose={() => { setShowUpgradeModal(false); setUpgradeTarget(null) }}
+          onSaved={async () => { await fetchMemberships(); setShowUpgradeModal(false); setUpgradeTarget(null) }}
+        />
+      )}
+    </div>
+  )
+}
+
+function EditMembershipModal({ membership, onClose, onSaved }: { membership: any, onClose: () => void, onSaved: () => void }) {
+  const supabase = createClient()
+  const [endDate, setEndDate] = useState<string>(membership.end_date || '')
+  const [nextBilling, setNextBilling] = useState<string>(membership.next_billing_date || '')
+  const [notes, setNotes] = useState<string>(membership.notes || '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSaving(true)
+    setError('')
+    try {
+      const updates: any = {
+        end_date: endDate || null,
+        next_billing_date: nextBilling || null,
+        notes: notes || null
+      }
+      const { error } = await supabase
+        .from('customer_memberships')
+        .update(updates)
+        .eq('id', membership.id)
+      if (error) throw error
+      await onSaved()
+    } catch (err: any) {
+      setError(err.message || 'Failed to save')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-md">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-white">Edit Membership</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">✕</button>
+        </div>
+        <form onSubmit={handleSave} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">End Date</label>
+            <input type="date" value={endDate || ''} onChange={(e) => setEndDate(e.target.value)} className="w-full bg-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Next Billing Date</label>
+            <input type="date" value={nextBilling || ''} onChange={(e) => setNextBilling(e.target.value)} className="w-full bg-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Notes</label>
+            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} className="w-full bg-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          </div>
+          {error && (
+            <div className="bg-red-600 bg-opacity-20 border border-red-600 rounded-lg p-3">
+              <p className="text-red-400 text-sm">{error}</p>
+            </div>
+          )}
+          <div className="flex gap-3">
+            <button type="button" onClick={onClose} className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600" disabled={saving}>Cancel</button>
+            <button type="submit" className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50" disabled={saving}>{saving ? 'Saving...' : 'Save Changes'}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function UpgradeMembershipModal({ membership, plans, onClose, onSaved }: { membership: any, plans: any[], onClose: () => void, onSaved: () => void }) {
+  const supabase = createClient()
+  const [planId, setPlanId] = useState<string>(membership.membership_plan_id || '')
+  const [effectiveDate, setEffectiveDate] = useState<string>(new Date().toISOString().split('T')[0])
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const handleUpgrade = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!planId) { setError('Please select a plan'); return }
+    setSaving(true)
+    setError('')
+    try {
+      const updates: any = {
+        membership_plan_id: planId,
+        start_date: effectiveDate
+      }
+      const { error } = await supabase
+        .from('customer_memberships')
+        .update(updates)
+        .eq('id', membership.id)
+      if (error) throw error
+      await onSaved()
+    } catch (err: any) {
+      setError(err.message || 'Failed to upgrade')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-gray-800 rounded-lg p-6 w-full max-w-md">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-white">Upgrade Membership</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-white">✕</button>
+        </div>
+        <form onSubmit={handleUpgrade} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">New Plan *</label>
+            <select value={planId} onChange={(e) => setPlanId(e.target.value)} className="w-full bg-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+              <option value="">Select a plan</option>
+              {plans.map((plan) => (
+                <option key={plan.id} value={plan.id}>
+                  {plan.name} - {formatBritishCurrency(plan.price || 0, true)}/{plan.billing_period || 'month'}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Effective From *</label>
+            <input type="date" value={effectiveDate} onChange={(e) => setEffectiveDate(e.target.value)} className="w-full bg-gray-700 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500" required />
+          </div>
+          {error && (
+            <div className="bg-red-600 bg-opacity-20 border border-red-600 rounded-lg p-3">
+              <p className="text-red-400 text-sm">{error}</p>
+            </div>
+          )}
+          <div className="flex gap-3">
+            <button type="button" onClick={onClose} className="flex-1 px-4 py-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600" disabled={saving}>Cancel</button>
+            <button type="submit" className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50" disabled={saving}>{saving ? 'Upgrading...' : 'Confirm Upgrade'}</button>
+          </div>
+        </form>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Description

Enhances the customer membership UI in the `MembershipsTab` to provide detailed views and management actions. Membership cards are now expandable, revealing comprehensive plan details, billing information, and notes. Users can now edit membership details (end date, next billing, notes), pause/resume, cancel, and upgrade memberships directly from the customer's membership tab.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

### Code Quality

- [x] **Solution works** - The code solves the problem/implements the feature as intended
- [x] **Minimal changes** - PR is scoped to one issue/feature (no unrelated modifications)
- [ ] **No lint/type errors** - Code passes `npm run typecheck` and `npm run lint`

### Testing

- [ ] **Tests added/updated** - Unit tests and/or E2E tests cover the changes
- [ ] **All tests passing** - `npm test` and `npm run test:e2e` succeed
- [ ] **Coverage maintained** - New code has adequate test coverage

### Security & Performance

- [ ] **No secrets in code** - API keys, passwords, tokens are in env vars only
- [ ] **Auth respected** - All new routes/APIs have proper authentication
- [ ] **Inputs validated** - User inputs are sanitized and validated
- [ ] **No performance issues** - No O(n²+) algorithms, N+1 queries, or memory leaks

### UI/UX (if applicable)

- [ ] **Accessibility** - WCAG 2.1 AA standards met (labels, contrast, keyboard nav)
- [ ] **Responsive design** - Works on mobile and desktop
- [ ] **Loading states** - Proper loading indicators and error handling
- [ ] **User feedback** - Success/error messages are clear

### Documentation

- [ ] **Code commented** - Complex logic has explanatory comments
- [ ] **Docs updated** - README/API docs updated if needed
- [ ] **CHANGELOG entry** - Added entry if user-facing change

## Testing Instructions

1.  Navigate to a customer's detail page and then to the "Memberships" tab.
2.  Add a new membership if none exist.
3.  Click on an existing membership card to expand its detailed view.
4.  Verify that plan details (price, frequency, start/end date, next billing date) and notes are displayed.
5.  Use the "Edit" button to change the membership's end date, next billing date, or notes, and save. Verify changes persist.
6.  Use the "Pause" / "Resume" button to change the membership status. Verify changes persist.
7.  Use the "Cancel" button to cancel a membership. Verify the status changes and end date is set to today.
8.  Use the "Upgrade" button to select a new plan and effective date. Verify changes persist.

## Risks & Follow-ups

-   Consider duplicating this detailed UI and functionality to `pages/customers/[id]/memberships.tsx` if a dedicated route is desired in the future.

## Screenshots/Videos

## AI Review Status

- [ ] Bug Hunt passed
- [ ] Code Review passed
- [ ] Security Review passed

---
<a href="https://cursor.com/background-agent?bcId=bc-6313c66b-d81b-485f-9dfc-048bb7256dd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6313c66b-d81b-485f-9dfc-048bb7256dd3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

