### PR TITLE
Fix lead form creation and visibility

### DIFF
--- a/app/lead-forms/page.tsx
+++ b/app/lead-forms/page.tsx
@@ -170,11 +170,30 @@ export default function LeadFormsPage() {
       }
       
       if (data.success) {
-        // For now, we'll show the form was generated
-        alert('Form generated successfully! Form saving functionality will be implemented.');
-        setShowFormBuilder(false);
-        setFormDescription('');
-        // In the future, this will save the form and redirect to form editor
+        // Save the generated form immediately
+        const saveResponse = await fetch('/api/forms/save', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data.form)
+        })
+        const saveData = await saveResponse.json()
+
+        if (!saveResponse.ok || !saveData?.form) {
+          throw new Error(saveData?.error || 'Failed to save generated form')
+        }
+
+        // Refresh forms list so it appears straight away
+        setTimeout(() => {
+          loadCustomForms()
+        }, 300)
+
+        // Open edit modal so user can name and tweak the form
+        setEditingForm(saveData.form)
+        setShowEditModal(true)
+
+        // Close builder modal and reset input
+        setShowFormBuilder(false)
+        setFormDescription('')
       }
     } catch (error: any) {
       console.error('Error generating form:', error);


### PR DESCRIPTION
## Description

This PR addresses a critical user experience issue where newly generated lead forms were not saved, displayed, or immediately editable after creation.

Previously, users would receive a success message but the form would not appear in their list, nor could it be named or configured. This change modifies the form creation flow to:
1.  **Immediately save** the generated form to the database.
2.  **Open the "Edit Form" modal** with the newly saved form, allowing users to name it and make initial adjustments.
3.  **Refresh the forms list** so the new form is visible under "Your Forms" right away.

This ensures a seamless and intuitive workflow for creating and managing lead forms.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist

### Code Quality

- [x] **Solution works** - The code solves the problem/implements the feature as intended
- [x] **Minimal changes** - PR is scoped to one issue/feature (no unrelated modifications)
- [x] **No lint/type errors** - Code passes `npm run typecheck` and `npm run lint`

### Testing

- [ ] **Tests added/updated** - Unit tests and/or E2E tests cover the changes
- [ ] **All tests passing** - `npm test` and `npm run test:e2e` succeed
- [ ] **Coverage maintained** - New code has adequate test coverage

### Security & Performance

- [ ] **No secrets in code** - API keys, passwords, tokens are in env vars only
- [ ] **Auth respected** - All new routes/APIs have proper authentication
- [ ] **Inputs validated** - User inputs are sanitized and validated
- [ ] **No performance issues** - No O(n²+) algorithms, N+1 queries, or memory leaks

### UI/UX (if applicable)

- [ ] **Accessibility** - WCAG 2.1 AA standards met (labels, contrast, keyboard nav)
- [ ] **Responsive design** - Works on mobile and desktop
- [ ] **Loading states** - Proper loading indicators and error handling
- [x] **User feedback** - Success/error messages are clear

### Documentation

- [ ] **Code commented** - Complex logic has explanatory comments
- [ ] **Docs updated** - README/API docs updated if needed
- [ ] **CHANGELOG entry** - Added entry if user-facing change

## Testing Instructions

1.  Navigate to `/lead-forms`.
2.  Click the "Create New Form" button.
3.  Enter a description for the form (e.g., "New client intake form").
4.  Click "Generate Form".
5.  Verify that the "Edit Form" modal automatically opens, pre-populated with the newly generated form's content.
6.  Enter a name for the form in the "Edit Form" modal and click "Save Changes".
7.  Verify that the newly named form now appears in the "Your Forms" list.

## Risks & Follow-ups

-   Consider adding a visual loading state while the form is being saved after generation.
-   Enhance error handling for the `/api/forms/save` call to provide more specific user feedback if saving fails.

## Screenshots/Videos

<!-- If UI changes, include before/after screenshots -->

## AI Review Status

- [ ] Bug Hunt passed
- [ ] Code Review passed
- [ ] Security Review passed

---
<a href="https://cursor.com/background-agent?bcId=bc-fac32a50-4542-4350-a2eb-4548c07210b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fac32a50-4542-4350-a2eb-4548c07210b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

