### PR TITLE
Fix facebook lead form mapping errors

### DIFF
--- a/app/lib/analytics/supabase-storage.ts
+++ b/app/lib/analytics/supabase-storage.ts
@@ -6,8 +6,8 @@ let supabase: any = null;
 
 function getSupabaseClient() {
   if (!supabase) {
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const supabaseUrl = (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim();
+    const serviceRoleKey = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
     
     if (!supabaseUrl || !serviceRoleKey) {
       console.warn('Supabase environment variables not configured, using mock client');

--- a/app/lib/supabase/client.ts
+++ b/app/lib/supabase/client.ts
@@ -1,12 +1,17 @@
 import { createBrowserClient } from '@supabase/ssr'
 import type { Database } from './database.types'
 
-export function createClient() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+let browserClient: ReturnType<typeof createBrowserClient<Database>> | null = null
 
-  return createBrowserClient<Database>(
+export function createClient() {
+  if (browserClient) return browserClient
+
+  const supabaseUrl = (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim()
+  const supabaseAnonKey = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').trim()
+
+  browserClient = createBrowserClient<Database>(
     supabaseUrl,
     supabaseAnonKey
   )
+  return browserClient
 }

--- a/app/lib/supabase/server.ts
+++ b/app/lib/supabase/server.ts
@@ -3,8 +3,8 @@ import { cookies } from 'next/headers'
 import type { Database } from './database.types'
 
 export async function createClient() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  const supabaseUrl = (process.env.NEXT_PUBLIC_SUPABASE_URL || '').trim()
+  const supabaseAnonKey = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '').trim()
 
   // During build time, return a mock client to prevent errors
   if (!supabaseUrl || !supabaseAnonKey) {


### PR DESCRIPTION
## Description

This PR addresses issues preventing Facebook lead form field mappings from being saved, which manifested as a 500 error on the `/api/integrations/facebook/field-mappings` endpoint. The root causes were identified as:
1.  Trailing newline characters in Supabase environment variables (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`), leading to malformed API keys in WebSocket connections and potential JSON parsing errors for cookies.
2.  Multiple instances of `GoTrueClient` being created in the browser, which can cause undefined authentication behavior.

The changes trim all relevant Supabase environment variables to remove newlines and implement a singleton pattern for the browser Supabase client to ensure only one instance exists.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## Checklist

### Code Quality

- [x] **Solution works** - The code solves the problem/implements the feature as intended
- [x] **Minimal changes** - PR is scoped to one issue/feature (no unrelated modifications)
- [x] **No lint/type errors** - Code passes `npm run typecheck` and `npm run lint`

### Testing

- [ ] **Tests added/updated** - Unit tests and/or E2E tests cover the changes
- [ ] **All tests passing** - `npm test` and `npm run test:e2e` succeed
- [ ] **Coverage maintained** - New code has adequate test coverage

### Security & Performance

- [x] **No secrets in code** - API keys, passwords, tokens are in env vars only
- [x] **Auth respected** - All new routes/APIs have proper authentication
- [ ] **Inputs validated** - User inputs are sanitized and validated
- [ ] **No performance issues** - No O(n²+) algorithms, N+1 queries, or memory leaks

### UI/UX (if applicable)

- [ ] **Accessibility** - WCAG 2.1 AA standards met (labels, contrast, keyboard nav)
- [ ] **Responsive design** - Works on mobile and desktop
- [ ] **Loading states** - Proper loading indicators and error handling
- [ ] **User feedback** - Success/error messages are clear

### Documentation

- [ ] **Code commented** - Complex logic has explanatory comments
- [ ] **Docs updated** - README/API docs updated if needed
- [ ] **CHANGELOG entry** - Added entry if user-facing change

## Testing Instructions

1.  Navigate to `https://atlas-fitness-onboarding.vercel.app/settings/integrations/facebook`.
2.  Perform a hard refresh (Shift + Reload) to ensure the new client code is loaded.
3.  Attempt to save the Facebook lead form field mappings.
4.  Verify that the mappings are saved successfully without errors.

## Risks & Follow-ups

-   None known.

## Screenshots/Videos

N/A

## AI Review Status

- [ ] Bug Hunt passed
- [ ] Code Review passed
- [ ] Security Review passed

---
<a href="https://cursor.com/background-agent?bcId=bc-baea846c-59d4-4eca-b651-8b6b4c5d444b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-baea846c-59d4-4eca-b651-8b6b4c5d444b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

